### PR TITLE
Encoding systemjs module name to work with Windows

### DIFF
--- a/SystemJSPublicPathWebpackPlugin.js
+++ b/SystemJSPublicPathWebpackPlugin.js
@@ -1,5 +1,5 @@
 const webpack = require("webpack");
-const path = require("path").posix;
+const path = require("path");
 
 const isWebpack5 = webpack.version && webpack.version.startsWith("5.");
 
@@ -25,7 +25,7 @@ class SystemJSPublicPathWebpackPlugin {
       additionalEntries.push(
         path.resolve(
           __dirname,
-          `resource-query-public-path?systemjsModuleName=${this.options.systemjsModuleName}&rootDirectoryLevel=${rootDirectoryLevel}`
+          `resource-query-public-path?systemjsModuleName=${encodeURIComponent(this.options.systemjsModuleName)}&rootDirectoryLevel=${rootDirectoryLevel}`
         )
       );
     }

--- a/resource-query-public-path.js
+++ b/resource-query-public-path.js
@@ -7,4 +7,4 @@ const queryObj = queryParts.reduce((result, queryPart) => {
   return result;
 }, {});
 
-setPublicPath(queryObj.systemjsModuleName, Number(queryObj.rootDirectoryLevel));
+setPublicPath(decodeURIComponent(queryObj.systemjsModuleName), Number(queryObj.rootDirectoryLevel));


### PR DESCRIPTION
- Encode the systemjsModuleName to avoid forward-slash to back-slash conversion
- Decode the systemjsModuleName when setting public path